### PR TITLE
Update Datadog Client Gem dependency

### DIFF
--- a/apm_traceable-datadog.gemspec
+++ b/apm_traceable-datadog.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 7.0.0'
   spec.add_dependency 'apm_traceable', '>= 1.0.0'
-  spec.add_dependency 'ddtrace', '>= 1.14.0'
+  spec.add_dependency 'datadog', '>= 2.2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
apm_traceable-datadogをRuby 3.4の環境でも利用できるようにする対応になります。

変更内容としては

- 2.0.0からddtraceがdatadogにリネームされたため、datadogを追加
- またdatadog 2.2.0からRuby 3.4をサポートし始めたため2.2.0以上を指定

となります。

手元のローカル環境でRuby 3.4.1で `bundle exec rake spec`を実行してテストがパスしていることは確認できています。
それ以外で何か動作確認など行うとよさそうな個所があれば共有していただけると幸いです。