### PR TITLE
Add resource name cache for improve performance

### DIFF
--- a/apm_traceable-datadog.gemspec
+++ b/apm_traceable-datadog.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 7.0.0'
   spec.add_dependency 'apm_traceable', '>= 1.0.0'
+  spec.add_dependency 'concurrent-ruby', '>= 1.3.0'
   spec.add_dependency 'datadog', '>= 2.2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/apm_traceable/adapters/datadog_adapter.rb
+++ b/lib/apm_traceable/adapters/datadog_adapter.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require 'active_support/inflector'
+require 'concurrent/map'
 require 'datadog/tracing'
 
 module ApmTraceable
   module Adapters
     # Datadogへトレース結果を送るためのアダプター
     class DatadogAdapter
+      RESOURCE_NAME_CACHE = Concurrent::Map.new
+      UNKNOWN_CLASS_NAME  = 'unknown_class'
+
       def initialize(service_name:)
         super()
 
@@ -26,8 +30,15 @@ module ApmTraceable
       attr_reader :service_name
 
       def resource_name(context_class)
-        # include 先のクラス名を利用して `admin.users_controller` のような文字列を作る
-        (context_class&.name || 'UnknownClass').underscore&.tr('/', '.')
+        key = context_class&.name
+
+        return UNKNOWN_CLASS_NAME unless key
+
+        # Concurrent::Mapを使い、既に生成済みのリソース名に関しては処理をスキップ
+        RESOURCE_NAME_CACHE.compute_if_absent(key) do
+          # include 先のクラス名を利用して `admin.users_controller` のような文字列を作る
+          key.underscore.tr('/', '.').freeze
+        end
       end
     end
   end


### PR DESCRIPTION
traceやtrace_methodsなどを定義したクラスで登録されたメソッドをループなどで複数回呼び出すとStringのオブジェクトが大量に生成されていることが分かりました。
またその影響から利用しているRailsアプリケーションで大量のデータを加工する際にかなりのメモリを使用していることも判明しました。

原因としてはApmTraceable::Adapters::DatadogAdapter#resource_nameがリソース名を加工する際に都度Stringを生成していたことが原因のようです。

そこでconcurrent-rubyを依存関係に追加し、Concurrent::Mapで処理済みのリソース名に関してはキャッシュしたものを使うように変更しています。

変更についてのベンチマークとしては以下を利用して計測しています。

```ruby

require 'benchmark'
require 'active_support/inflector'
require 'concurrent/map'

module Admin
  class UsersController; end
  class TeamsController; end
  class ReportsController; end
end

module Legacy
  module_function

  def resource_name(context_class)
    (context_class&.name || 'UnknownClass').underscore.tr('/', '.')
  end
end

module Cached
  CACHE = Concurrent::Map.new
  UNKNOWN = 'unknown_class'

  module_function

  def resource_name(context_class)
    return UNKNOWN unless context_class&.name

    CACHE.compute_if_absent(context_class) do
      context_class.name.underscore.tr('/', '.').freeze
    end
  end
end

def measure_allocations(label, iterations)
  GC.start
  GC.disable
  before = GC.stat(:total_allocated_objects)
  elapsed = Benchmark.realtime { yield }
  after = GC.stat(:total_allocated_objects)
  GC.enable

  puts format(
    "%-30s time=%0.4fs alloc=%d",
    label,
    elapsed,
    after - before
  )
end

ITERATIONS = 1_000_000
CLASSES = [
  Admin::UsersController,
  Admin::TeamsController,
  Admin::ReportsController
].freeze

100_000.times do
  CLASSES.each { |klass| Cached.resource_name(klass) }
  Cached.resource_name(nil)
end

measure_allocations('legacy same class', ITERATIONS) do
  ITERATIONS.times { Legacy.resource_name(Admin::UsersController) }
end

measure_allocations('cached same class', ITERATIONS) do
  ITERATIONS.times { Cached.resource_name(Admin::UsersController) }
end

measure_allocations('legacy 3 classes', ITERATIONS) do
  ITERATIONS.times { |i| Legacy.resource_name(CLASSES[i % CLASSES.size]) }
end

measure_allocations('cached 3 classes', ITERATIONS) do
  ITERATIONS.times { |i| Cached.resource_name(CLASSES[i % CLASSES.size]) }
end

measure_allocations('legacy nil', ITERATIONS) do
  ITERATIONS.times { Legacy.resource_name(nil) }
end

measure_allocations('cached nil', ITERATIONS) do
  ITERATIONS.times { Cached.resource_name(nil) }
end
```

計測結果としては以下のようになっています。
実行時間の短縮とアロケーション数が削減できています。

```bash
sh@DESKTOP-L0NI312:~/oss/apm_traceable-datadog$ ruby bench.rb
legacy same class              time=4.0837s alloc=8000013
cached same class              time=0.2488s alloc=3
legacy 3 classes               time=3.5137s alloc=8000004
cached 3 classes               time=0.3083s alloc=4
legacy nil                     time=2.5891s alloc=7000002
cached nil                     time=0.0816s alloc=2
```